### PR TITLE
chore(angular): Improve dark theme

### DIFF
--- a/angular/src/app/navigation-bar/navigation-bar.component.scss
+++ b/angular/src/app/navigation-bar/navigation-bar.component.scss
@@ -2,10 +2,12 @@
 @import "node_modules/bootstrap/scss/variables";
 @import "node_modules/bootstrap/scss/mixins";
 
+$color-mode-type: media-query;
+
 nav {
   border-bottom: 1px solid $gray-400;
   box-shadow: 0 0 10px 0 $gray-400;
-  @media (prefers-color-scheme: dark) {
+  @include color-mode(dark) {
     border-bottom-color: $green-800;
     box-shadow: 0 0 10px 0 $gray-800;
   }

--- a/angular/src/app/ongoing-game/ongoing-game-page.component.html
+++ b/angular/src/app/ongoing-game/ongoing-game-page.component.html
@@ -9,7 +9,7 @@
 
   <ng-container content>
     <shpp-card-table class="flex-grow-1" />
-    <shpp-turn-summary *ngIf="showSummary" class="bg-light" />
-    <shpp-card-picker *ngIf="!showSummary" class="bg-light" />
+    <shpp-turn-summary *ngIf="showSummary" class="bg-body-secondary" />
+    <shpp-card-picker *ngIf="!showSummary" class="bg-body-secondary" />
   </ng-container>
 </shpp-container>

--- a/angular/src/app/ongoing-game/ongoing-game-page.component.scss
+++ b/angular/src/app/ongoing-game/ongoing-game-page.component.scss
@@ -1,5 +1,8 @@
 @import "bootstrap/scss/functions";
 @import "bootstrap/scss/variables";
+@import "bootstrap/scss/mixins";
+
+$color-mode-type: media-query;
 
 :host {
   flex-grow: 1;
@@ -7,14 +10,14 @@
   flex-direction: column;
 }
 
-.bg-light {
-  border-top: 1px solid $gray-100;
-  box-shadow: 0 0 10px 0 $gray-300;
+.bg-body-secondary {
+  border-top: 1px solid $gray-300;
+  box-shadow: 0 0 10px 0 $gray-400;
 
-  @media (prefers-color-scheme: dark) {
-    background-color: $gray-900 !important;
-    border-top-color: $gray-800;
-    box-shadow: 0 0 10px 0 $gray-800;
+  @include color-mode(dark) {
+    // background-color: $gray-900 !important;
+    border-top-color: $gray-800 !important;
+    box-shadow: 0 0 10px 0 $gray-800 !important;
   }
 }
 

--- a/angular/src/styles.scss
+++ b/angular/src/styles.scss
@@ -2,22 +2,13 @@
 
 $primary: #198754;
 $enable-shadows: true;
+$color-mode-type: media-query;
 
 /* Importing Bootstrap SCSS file. */
 @import 'bootstrap/scss/bootstrap';
 
 :root {
   --card-color: #{$green-500};
-}
-
-@media (prefers-color-scheme: dark) {
-  body {
-    background-color: $gray-800;
-    color: white;
-  }
-  .offcanvas {
-    background-color: $gray-900;
-  }
 }
 
 .bg-primary {
@@ -54,7 +45,7 @@ $enable-shadows: true;
     box-shadow: 0 0 15px 0 $gray-400;
   }
 
-  @media (prefers-color-scheme: dark) {
+  @include color-mode(dark) {
     background-color: $gray-800;
     color: white;
     &:not(.card-disabled, .dashed) {
@@ -72,7 +63,7 @@ $enable-shadows: true;
   background: $gray-200;
   outline-color: $gray-600;
   color: $gray-700;
-  @media (prefers-color-scheme: dark) {
+  @include color-mode(dark) {
     background: $gray-800;
     color: $gray-600;
   }


### PR DESCRIPTION
Following the release of [Bootstrap 5.3.0], Bootstrap now natively supports dark mode. While my previous attempt was more of a hack, inputs and close buttons now display as expected.

(left: Bootstrap 5.3, right: Bootstrap 5.2)
![image](https://github.com/axeleroy/self-host-planning-poker/assets/3141536/acf0c5c6-6daa-45f7-b87f-12f923890a6b)
