### PR TITLE
Update Dockerfile to let the app run without root permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,21 @@
-FROM --platform=$BUILDPLATFORM node:lts-slim AS node_builder
+FROM --platform=$BUILDPLATFORM docker.io/library/node:lts-slim AS node_builder
 WORKDIR /angular
 COPY angular/ /angular
-RUN npm i
+RUN npm config set update-notifier false && \
+  npm config set fund false && \
+  npm config set audit false && \
+  npm ci
 RUN npm run build self-host-planning-poker
 
-FROM python:3.11.7-alpine3.18
+FROM docker.io/library/python:3.11.7-alpine3.18
+RUN adduser -H -D -u 1001 -G root default
 WORKDIR /app
-COPY flask/ ./
-RUN pip install -r requirements.txt
-COPY --from=node_builder /angular/dist/self-host-planning-poker ./static
+COPY --chown=1001:0 flask/ ./
+COPY --chown=1001:0 --from=node_builder /angular/dist/self-host-planning-poker ./static
+RUN pip install --upgrade pip && \
+  pip install --requirement requirements.txt && \
+  mkdir /data && \
+  chown -R 1001:0 /app /data && \
+  chmod -R g+w /app /data
+USER 1001
 CMD [ "gunicorn", "--worker-class", "eventlet", "-w", "1", "app:app", "--bind", "0.0.0.0:8000" ]


### PR DESCRIPTION
Hello,

In this pull request the the Dockerfile is updated mainly to let the app/container run rootless.
This is handy if you want to run the app/container in a environment when running as root is not allowed.
For example a Kubernetes platform with Restricted Pod Security Standards[1] / Security Context[2]

There is also a modification to support arbitrary user ids [3]. 

Also the `/data` directory is created during the build with the correct permissions. This makes the `-v planning-poker-data:/data` option optional.

Finally the full registry path is used at the `FROM` instructions to clarify where the image comes from.

[1] [Pod security standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
[2] [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
[3] [Support arbitrary user ids](https://docs.openshift.com/container-platform/4.15/openshift_images/create-images.html#use-uid_create-images)