### PR TITLE
feat: add confidence votes deck

### DIFF
--- a/angular/src/app/model/deck.ts
+++ b/angular/src/app/model/deck.ts
@@ -71,6 +71,23 @@ export const decks: Deck[] = [
     ]
   },
   {
+    name: 'CONFIDENCE_VOTES',
+    textValues: false,
+    values: [
+      { value: 0, display: 0 },
+      { value: 1, display: 1 },
+      { value: 2, display: 2 },
+      { value: 3, display: 3 },
+      { value: 4, display: 4 },
+      { value: 5, display: 5 },
+      { value: 6, display: 6 },
+      { value: 7, display: 7 },
+      { value: 8, display: 8 },
+      { value: 9, display: 9 },
+      { value: 10, display: 10 },
+    ]
+  },
+  {
     name: 'T_SHIRTS',
     textValues: true,
     values: [

--- a/angular/src/app/model/deck.ts
+++ b/angular/src/app/model/deck.ts
@@ -68,18 +68,6 @@ export const decks: Deck[] = [
       { value: 3, display: 3 },
       { value: 4, display: 4 },
       { value: 5, display: 5 },
-    ]
-  },
-  {
-    name: 'CONFIDENCE_VOTES',
-    textValues: false,
-    values: [
-      { value: 0, display: 0 },
-      { value: 1, display: 1 },
-      { value: 2, display: 2 },
-      { value: 3, display: 3 },
-      { value: 4, display: 4 },
-      { value: 5, display: 5 },
       { value: 6, display: 6 },
       { value: 7, display: 7 },
       { value: 8, display: 8 },

--- a/flask/gamestate/deck.py
+++ b/flask/gamestate/deck.py
@@ -6,5 +6,5 @@ class Deck(Enum):
     FIBONACCI = [0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89]
     MODIFIED_FIBONACCI = [0, 0.5, 1, 2, 3, 5, 8, 13, 20, 40, 100]
     POWERS = [0, 1, 2, 4, 8, 16, 32, 64]
-    TRUST_VOTE = [0, 1, 2, 3, 4, 5]
+    TRUST_VOTE = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     T_SHIRTS = [1, 2, 3, 4, 5, 6, 7]  # Each value maps to a t-shirt size from XXS to XXL


### PR DESCRIPTION
As part of our objective/key results, we vote on confidence in finishing the KR by the end of a quarter. And we vote it from 0-10.
We love your app. Please merge this and release it for us to use this feature. It'd be incredibly useful to have it in the dropdown.