### PR TITLE
feat: add "non vote" cards

### DIFF
--- a/angular/src/app/model/deck.ts
+++ b/angular/src/app/model/deck.ts
@@ -9,6 +9,9 @@ export interface Deck {
   values: CardValue[];
 }
 
+// Predefined decks
+// Cards can have negative values, to define special cards like "?" or "coffee".
+// Cards with negative values are ignored when calculating averages and agreement.
 export const decks: Deck[] = [
   {
     name: 'FIBONACCI',
@@ -25,6 +28,8 @@ export const decks: Deck[] = [
       { value: 34, display: 34 },
       { value: 55, display: 55 },
       { value: 89, display: 89 },
+      { value: -1, display: "?" },
+      { value: -2, display: "☕" },
     ]
   },
   {
@@ -42,6 +47,8 @@ export const decks: Deck[] = [
       { value: 20, display: 20 },
       { value: 40, display: 40 },
       { value: 100, display: 100 },
+      { value: -1, display: "?" },
+      { value: -2, display: "☕" },
     ]
   },
   {
@@ -56,6 +63,8 @@ export const decks: Deck[] = [
       { value: 16, display: 16 },
       { value: 32, display: 32 },
       { value: 64, display: 64 },
+      { value: -1, display: "?" },
+      { value: -2, display: "☕" },
     ]
   },
   {
@@ -68,6 +77,8 @@ export const decks: Deck[] = [
       { value: 3, display: 3 },
       { value: 4, display: 4 },
       { value: 5, display: 5 },
+      { value: -1, display: "?" },
+      { value: -2, display: "☕" },
     ]
   },
   {
@@ -81,6 +92,8 @@ export const decks: Deck[] = [
       { value: 5, display: 'L' },
       { value: 6, display: 'XL' },
       { value: 7, display: 'XXL' },
+      { value: -1, display: "?" },
+      { value: -2, display: "☕" },
     ]
   }
 ]

--- a/angular/src/app/ongoing-game/turn-summary/turn-summary.component.ts
+++ b/angular/src/app/ongoing-game/turn-summary/turn-summary.component.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
-import { PlayerState } from '../../model/events';
+import { PlayerState, GameInfo, GameState } from '../../model/events';
 import { filter, map, Observable, Subscription, tap, withLatestFrom } from 'rxjs';
 import { Deck, decksDict, displayCardValue } from '../../model/deck';
 import { AsyncPipe, KeyValue, KeyValuePipe, NgClass, NgFor } from '@angular/common';
@@ -45,7 +45,7 @@ export class TurnSummaryComponent implements AfterViewInit, OnDestroy {
         }
       }),
       map(([gameState]) => Object.values(gameState)),
-      map((playerStates: PlayerState[]) => playerStates.filter((state) => state.hand !== undefined && state.hand !== null))
+      map((playerStates: PlayerState[]) => playerStates.filter((state) => state.hand !== undefined && state.hand !== null && state.hand >= 0))
     );
 
     this.$counts = this.$playerStates
@@ -66,8 +66,10 @@ export class TurnSummaryComponent implements AfterViewInit, OnDestroy {
 
     this.subscriptions.concat(
       this.$playerStates.pipe(
-        map((players: PlayerState[]) =>
-          players.reduce((prev, current) => prev + (current.hand || 0), 0) / players.length || 0))
+        map((players: PlayerState[]) => 
+          players.length > 0 
+            ? players.reduce((prev, current) => prev + (current.hand || 0), 0) / players.length 
+            : 0))
       .subscribe((value) => this.average = value));
 
     this.subscriptions.concat(

--- a/flask/gamestate/deck.py
+++ b/flask/gamestate/deck.py
@@ -3,8 +3,8 @@ from enum import Enum
 
 class Deck(Enum):
     """List of the decks of cards available"""
-    FIBONACCI = [0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89]
-    MODIFIED_FIBONACCI = [0, 0.5, 1, 2, 3, 5, 8, 13, 20, 40, 100]
-    POWERS = [0, 1, 2, 4, 8, 16, 32, 64]
-    TRUST_VOTE = [0, 1, 2, 3, 4, 5]
-    T_SHIRTS = [1, 2, 3, 4, 5, 6, 7]  # Each value maps to a t-shirt size from XXS to XXL
+    FIBONACCI = [0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, -1, -2]
+    MODIFIED_FIBONACCI = [0, 0.5, 1, 2, 3, 5, 8, 13, 20, 40, 100, -1, -2]
+    POWERS = [0, 1, 2, 4, 8, 16, 32, 64, -1, -2]
+    TRUST_VOTE = [0, 1, 2, 3, 4, 5, -1, -2]
+    T_SHIRTS = [1, 2, 3, 4, 5, 6, 7, -1, -2]  # Each value maps to a t-shirt size from XXS to XXL


### PR DESCRIPTION
Some teams are using special cards that does not represent an estimation. For instance, the "question mark" for players that are not confident to estimate an item, or the "coffee" card when a player needs a break.

This PR adds those two cards, and makes it easy to define other special cards: any card with a negative value in any deck is deemed to be a special card, that will be ignored when calculating the average and the agreement.